### PR TITLE
Add feedback buttons to chat messages

### DIFF
--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { Message, useChatContext } from '@/contexts/ChatContext';
+import { Button } from './Button';
+
+export const FeedbackButton = ({ message }: { message: Message }) => {
+  const { messageId, actor, feedback: initialFeedback } = message;
+  const [feedback, setFeedback] = useState(initialFeedback);
+  const { sendAction } = useChatContext();
+
+  const sendFeedback = (label) => {
+    const choice = feedback == 'none' ? label : 'none';
+    setFeedback(choice);
+    sendAction({ messageId, choice });
+  };
+  return feedback == 'n/a' || actor != 'bot' ? (
+    <></>
+  ) : (
+    <>
+      <Button
+        key="good"
+        onClick={() => sendFeedback('good')}
+        disabled={feedback == 'bad'}
+        className="disabled:bg-gray-400"
+      >
+        👍
+      </Button>
+      <Button
+        key="bad"
+        onClick={() => sendFeedback('bad')}
+        disabled={feedback == 'good'}
+        className="disabled:bg-gray-400"
+      >
+        👎
+      </Button>
+    </>
+  );
+};

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -1,3 +1,4 @@
+import { FeedbackButton } from '@/components/FeedbackButton';
 import { MessageTranslator } from '@/components/MessageTranslator';
 import { Message, useChatContext } from '@/contexts/ChatContext';
 
@@ -19,6 +20,7 @@ export const MessageItem = ({ message }: { message: Message }) => {
       />
       <div className={`text-md w-full overflow-hidden rounded-md pl-4 leading-7`}>
         <MessageTranslator message={payload} />
+        <FeedbackButton message={message} />
       </div>
     </div>
   );

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -1,10 +1,13 @@
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import useWebSocket from 'react-use-websocket';
+import { JsonValue } from 'react-use-websocket/dist/lib/types';
 import { useModalContext } from '@/contexts/ModalContext';
 
 export type Message = {
+  messageId: string;
   actor: string;
   payload: string;
+  feedback: string;
 };
 
 // type UserMessage = Omit<Message, 'avatar'>;
@@ -12,6 +15,7 @@ export type Message = {
 export type ChatContextType = {
   messages: Message[];
   sendMessage: (msg: string) => void;
+  sendAction: (action: JsonValue) => void;
   spoofBotMessage: (msg: string) => void;
   getAvatar: (actor: string) => string;
   isBotThinking: boolean;
@@ -26,11 +30,14 @@ const getAvatar = (actor: string) =>
 const initialContext = {
   messages: [
     {
+      messageId: '',
       actor: 'bot',
       payload: 'Hello 👋, how can I help you?',
+      feedback: 'n/a',
     },
   ],
   sendMessage: (msg: string) => {},
+  sendAction: (action: JsonValue) => {},
   spoofBotMessage: (msg: string) => {},
   getAvatar,
   isBotThinking: false,
@@ -69,15 +76,19 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
     }
     setIsBotThinking(obj.stillThinking);
     const msg = {
+      messageId: obj.messageId || '',
       payload,
       actor,
+      feedback: obj.feedback || 'none',
     };
     setMessages((messages) => {
       if (obj.operation == 'append') {
         const lastMsg = messages[messages.length - 1];
         const appendedMsg = {
+          messageId: lastMsg.messageId,
           payload: lastMsg.payload + msg.payload,
           actor: lastMsg.actor,
+          feedback: lastMsg.feedback,
         };
         return [...messages.slice(0, -1), appendedMsg];
       } else if (obj.operation == 'replace') {
@@ -94,10 +105,16 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
     setMessages([
       ...messages,
       {
+        messageId: '',
         actor: 'user',
         payload: msg,
+        feedback: 'n/a',
       },
     ]);
+  };
+
+  const sendAction = (action: JsonValue) => {
+    wsSendMessage({ actor: 'user', type: 'action', payload: action });
   };
 
   const spoofBotMessage = (msg: string) => {
@@ -106,8 +123,10 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
       setMessages([
         ...messages,
         {
+          messageId: '',
           actor: 'bot',
           payload: msg,
+          feedback: 'n/a',
         },
       ]);
       setIsBotThinking(false);
@@ -119,6 +138,7 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
       value={{
         messages,
         sendMessage,
+        sendAction,
         getAvatar,
         isBotThinking,
         spoofBotMessage,


### PR DESCRIPTION
Address #64.

Feel free to restyle it.

Currently, you can undo feedback by toggling the button that was pressed previously. Also, actions are sent to the backend and persisted with the session as well.

Check out an example session here: https://chatweb3.func.ai/?s=5ac4c51f-61a3-4339-b903-062ef7709586
