### PR TITLE
Add support for function messages

### DIFF
--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -53,6 +53,8 @@ export const MessageItem = ({ message }: { message: Message }) => {
           <MessageTranslator message={payload} />
         ) : actor === 'system' ? (
           <SystemMessage message={payload} />
+        ) : actor === 'function' ? (
+          <SystemMessage message={payload} />
         ) : (
           <UserMessage
             {...{

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -40,7 +40,7 @@ export const MessageList = () => {
   return (
     <div className="h-full">
       {messages.map((message, i) => {
-        if (!showDebugMessages && message.actor == 'system') {
+        if (!showDebugMessages && (message.actor === 'system' || message.actor === 'function')) {
           return <React.Fragment key={message.messageId} />;
         }
         return (

--- a/src/components/experimental_/MessageItem_.tsx
+++ b/src/components/experimental_/MessageItem_.tsx
@@ -36,6 +36,7 @@ export const MessageItem = ({ message }: { message: Message }) => {
     <div className={`flex w-full flex-col`}>
       {actor === 'bot' && <MessageTranslator message={message} />}
       {actor === 'system' && <SystemMessage message={payload} />}
+      {actor === 'function' && <SystemMessage message={payload} />}
       {isUser && (
         <UserMessage
           {...{

--- a/src/components/experimental_/MessageList_.tsx
+++ b/src/components/experimental_/MessageList_.tsx
@@ -30,7 +30,7 @@ export const MessageList = () => {
   return (
     <div className="h-full pt-8">
       {messages.map((message, i) => {
-        if (!showDebugMessages && message.actor == 'system') {
+        if (!showDebugMessages && (message.actor === 'system' || message.actor === 'function')) {
           return <React.Fragment key={message.messageId} />;
         }
 


### PR DESCRIPTION
Allow function messages to show up in debug output like a system message.

Only applies to ChatGPT function chat module.

These are stored in the DB, and used to restore ChatHistory with these messages for subsequent API call.

<img width="935" alt="image" src="https://github.com/yieldprotocol/cacti-frontend/assets/141746/ade92ad5-0317-4362-8af6-31e28673bfd9">
