### PR TITLE
Add a message type to clear frontend messages

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -108,6 +108,12 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
       : router.query.id?.[0]
     : null;
 
+  const resetMessages = () => {
+    setMessages([]);
+    setResumeFromMessageId(null);
+    setInsertBeforeMessageId(null);
+  };
+
   useEffect(() => {
     // re-initialize on change
     if (status === 'loading') {
@@ -125,9 +131,7 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
       needsReset = true;
     }
     if (needsReset) {
-      setMessages([]);
-      setResumeFromMessageId(null);
-      setInsertBeforeMessageId(null);
+      resetMessages();
       wsSendMessage({ actor: 'system', type: 'clear', payload: {} });
       if (sessionId) {
         wsSendMessage({ actor: 'system', type: 'init', payload: { sessionId } });
@@ -186,7 +190,10 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
     if (!lastMessage) return;
 
     const obj = JSON.parse(lastMessage.data);
-    if (obj.type == 'uuid') {
+    if (obj.type == 'clear') {
+      resetMessages();
+      return;
+    } else if (obj.type == 'uuid') {
       const newSessionId = obj.payload;
       setLastInitSessionId(newSessionId);
       router.replace(`/chat/${newSessionId}`);


### PR DESCRIPTION
This will be sent by backend prior to loading messages of a session after an init.

Even though we clear this on the frontend, the backend might still have messages in the pipe being sent over that needs to be cleared.

This can be further improved if we include session id to the messages so we can do some filtering on the frontend for messages that aren't relevant to the session.