### PR TITLE
task: wrap text display in markdown component and polish workflow spinner 

### DIFF
--- a/src/components/cactiComponents/TextResponse.tsx
+++ b/src/components/cactiComponents/TextResponse.tsx
@@ -1,5 +1,6 @@
 import { Disclosure } from '@headlessui/react';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
+import { Markdown } from '../experimental_/Markdown';
 import { ResponseTitle, ResponseWrap } from './helpers/layout';
 
 /**
@@ -18,7 +19,11 @@ export const TextResponse = (props: any) => {
         </>
       )}
 
-      {!props.title && <div className=" text-base text-white text-opacity-70">{props.text}</div>}
+      {!props.title && (
+        <div className=" text-base text-white text-opacity-70">
+          <Markdown>{props.text}</Markdown>
+        </div>
+      )}
 
       {props.title && props.collapsible && (
         <Disclosure as="div" defaultOpen>

--- a/src/components/experimental_/Markdown.tsx
+++ b/src/components/experimental_/Markdown.tsx
@@ -2,5 +2,15 @@ import ReactMarkdown from 'react-markdown';
 
 //======================================
 export const Markdown = ({ children }: { children: string }) => {
-  return <ReactMarkdown>{children}</ReactMarkdown>;
+  return (
+    <ReactMarkdown
+      components={{
+        ul: (props) => <ul className="list-disc" {...props} />,
+        a: (props) => <a className="text-blue-400 underline" {...props} />,
+        code: (props) => <code className="text-orange-300" {...props} />,
+      }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
 };

--- a/src/components/experimental_/MultiStepProgressIndicator.tsx
+++ b/src/components/experimental_/MultiStepProgressIndicator.tsx
@@ -21,11 +21,8 @@ export const MultiStepProgressIndicator = () => {
       >
         <ResponseWrap>
           <div className="cen flex w-full justify-center">
-            <Spinner className="h-4 w-4 text-white" />
-            <div>
-              There are more steps in the current workflow, please wait as the system computes the
-              next step.
-            </div>
+            <Spinner className="mx-2 my-1 h-4 w-4 text-white" />
+            <div>There are more steps in the current workflow, please wait for next step...</div>
           </div>
         </ResponseWrap>
       </div>


### PR DESCRIPTION
* Wrapped general text response with markdown component
* Customized the style of certain markdown elements, such as `li`, `a`, `code`, to polish the UI for general app info markdown response
<img width="1145" alt="Screen Shot 2023-08-07 at 11 28 45 PM" src="https://github.com/yieldprotocol/cacti-frontend/assets/4344342/8866b317-59a6-4aad-a891-099c425caedd">

* Added margin to the workflow spinner