### PR TITLE
remove extra onSuccess() call

### DIFF
--- a/src/components/cactiComponents/hooks/useSubmitTx.tsx
+++ b/src/components/cactiComponents/hooks/useSubmitTx.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
 import { useAddRecentTransaction } from '@rainbow-me/rainbowkit';
-import { CallOverrides, Overrides, PayableOverrides, UnsignedTransaction } from 'ethers';
+import {
+  CallOverrides,
+  Overrides,
+  PayableOverrides,
+  UnsignedTransaction,
+} from 'ethers';
 import {
   usePrepareContractWrite,
   usePrepareSendTransaction,
@@ -32,13 +38,14 @@ export const SEND_ETH_FNNAME = '8bb05f0e-05ed-11ee-be56-0242ac120002';
  * @param sendParams the send transaction parameters to prepare and submit
  * @param onSuccess callback to run on success
  * @param onError callback to run on error
+ * @param description description of tx for wallet
  */
 const useSubmitTx = (
   params?: TxBasicParams,
   sendParams?: UnsignedTransaction,
-  onSuccess?: () => void,
-  onError?: () => void,
-  label?: string
+  onSuccess?: (receipt?: TransactionReceipt) => void,
+  onError?: (receipt?: TransactionReceipt) => void,
+  description?: string
 ) => {
   const addRecentTx = useAddRecentTransaction();
   const { refetch: refetchEthBal } = useBalance();
@@ -70,15 +77,15 @@ const useSubmitTx = (
     isLoading: isPending,
     isError,
     isSuccess,
+    status
   } = useWaitForTransaction({
     hash: data?.hash,
     onSuccess: () => {
-      if (onSuccess) onSuccess();
+      if (onSuccess) onSuccess(receipt);
       refetchEthBal();
     },
     onError: (e) => {
-      console.log('tx error', e);
-      if (onError) onError();
+      if (onError) onError(receipt);
     },
   });
 
@@ -87,10 +94,10 @@ const useSubmitTx = (
     if (data?.hash) {
       addRecentTx({
         hash: data.hash,
-        description: label ?? params?.functionName ?? '',
+        description: description ?? params?.functionName ?? '',
       });
     }
-  }, [addRecentTx, data?.hash, label, params?.functionName]);
+  }, [addRecentTx, data?.hash, description, params?.functionName]);
 
   /* DEVELOPER logging */
   useEffect(() => {
@@ -113,6 +120,7 @@ const useSubmitTx = (
     isPending,
     isSuccess,
     error,
+    status
   };
 };
 

--- a/src/components/experimental_/containers/MultiStepContainer.tsx
+++ b/src/components/experimental_/containers/MultiStepContainer.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { UnsignedTransaction } from 'ethers';
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
 import { useChatContext } from '@/contexts/ChatContext';
 import { ActionResponse, HeaderResponse } from '../../cactiComponents';
 import { WidgetError } from '../widgets/helpers';
@@ -114,12 +115,12 @@ export const UserActionTxType = ({
   sendStepResult,
   description,
 }: UserActionTxTypeProps) => {
-  const handleSuccess = (txHash?: string) => {
-    sendStepResult('success', `Transaction successful`, txHash || '');
+  const handleSuccess = (receipt?: TransactionReceipt) => {
+    sendStepResult('success', `Transaction successful`, receipt?.transactionHash || '');
   };
 
-  const handleError = (txHash?: string) => {
-    sendStepResult('error', `Transaction failed`, txHash || '');
+  const handleError = (receipt?: TransactionReceipt) => {
+    sendStepResult('error', `Transaction failed`, receipt?.transactionHash || '');
   };
 
   const unsignedTx: UnsignedTransaction = {


### PR DESCRIPTION
Removes the extra  onSuccess() call causing ENS (and other issues). 

note: also extended the onSuccess paramters to use a TransactionReciept ( which includes the transaction hash as well as other useful things related to the tx - like success, gas used etc.) 

Also, action reponse takes the params ; 
label: which shows any custom text on the button instead of  'Submit Transaction' ( eg. Buy NFT  )
description: Which gets added as the description sent to the wallet ( eg.  Buy Cheetah #345 from Opensea )