### PR TITLE
adding double check for links in markdown

### DIFF
--- a/src/components/current/Markdown.tsx
+++ b/src/components/current/Markdown.tsx
@@ -1,16 +1,25 @@
+import React, { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 //======================================
 export const Markdown = ({ children }: { children: string }) => {
+  // regex to match URLs in text that arent already formatted as links in markdown
+  const urlRegex = /(?<!\]\()https?:\/\/[^\s]+(?!\))/g;
+
+  // add markdown syntax to format links in text if they aren't already marked
+  const processedText = children.replace(urlRegex, (url) => `[${url}](${url})`);
+
   return (
     <ReactMarkdown
       components={{
         ul: (props) => <ul className="list-disc" {...props} />,
-        a: (props) => <a className="text-blue-400 underline" {...props} />,
+        a: (props) => (
+          <a className="testerino text-blue-400 underline" target="_blank" {...props} />
+        ),
         code: (props) => <code className="text-orange-300" {...props} />,
       }}
     >
-      {children}
+      {processedText}
     </ReactMarkdown>
   );
 };


### PR DESCRIPTION
- added regex to parse text in markdown component. If a URL has already been formatted as a link in markdown, we let it be. if it hasn't we make it a link
- make links open in new tab