### PR TITLE
reverting markdown change

### DIFF
--- a/src/components/current/Markdown.tsx
+++ b/src/components/current/Markdown.tsx
@@ -3,12 +3,6 @@ import ReactMarkdown from 'react-markdown';
 
 //======================================
 export const Markdown = ({ children }: { children: string }) => {
-  // regex to match URLs in text that arent already formatted as links in markdown
-  const urlRegex = /(?<!\]\()https?:\/\/[^\s]+(?!\))/g;
-
-  // add markdown syntax to format links in text if they aren't already marked
-  const processedText = children.replace(urlRegex, (url) => `[${url}](${url})`);
-
   return (
     <ReactMarkdown
       components={{
@@ -19,7 +13,7 @@ export const Markdown = ({ children }: { children: string }) => {
         code: (props) => <code className="text-orange-300" {...props} />,
       }}
     >
-      {processedText}
+      {children}
     </ReactMarkdown>
   );
 };


### PR DESCRIPTION
- reverting markdown change because an improved prompt is formatting properly and regex was causing some unintended consequences